### PR TITLE
Enable offline questionnaire mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A página de conexão e início do Pomodoro está disponível em:
 
 👉 **https://gmraffo.github.io/webautomato/**
 
+Caso o ESP32 não esteja disponível, a tela inicial permite seguir para os questionários
+mesmo sem realizar a conexão com o dispositivo.
+
 ---
 
 ## ⚙️ O que o código faz

--- a/js/wifi.js
+++ b/js/wifi.js
@@ -28,15 +28,19 @@ if (wifiForm) {
 
       if (result.success) {
         statusDiv.innerText = "Conectado com sucesso!";
-        setTimeout(() => {
-          window.location.href = "pre.html"; //passa para próxima página
-        }, 1000);
       } else {
-        statusDiv.innerText = "Falha ao conectar.";
+        statusDiv.innerText = "Falha ao conectar. Prosseguindo sem dispositivo.";
       }
+
+      setTimeout(() => {
+        window.location.href = "pre.html"; // passa para a página de questionário
+      }, 1000);
     } catch (err) {
-      statusDiv.innerText = "Erro de conexão. Tente novamente.";
+      statusDiv.innerText = "Não foi possível conectar ao ESP32. Prosseguindo em modo de pesquisa.";
       console.error(err);
+      setTimeout(() => {
+        window.location.href = "pre.html";
+      }, 1000);
     }
   });
 }


### PR DESCRIPTION
## Summary
- allow progressing to questionnaires even when the connection to the ESP32 fails
- document that the website can be used without the device

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464c1ac1f483318b58d784836049f9