### PR TITLE
Add offline skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A página de conexão e início do Pomodoro está disponível em:
 
 👉 **https://gmraffo.github.io/webautomato/**
 
+Caso o ESP32 não esteja disponível, a tela inicial permite seguir para os questionários
+mesmo sem realizar a conexão com o dispositivo.
+Há também o botão **"Continuar sem conectar"**, que leva direto ao questionário inicial.
+Um aviso logo abaixo do botão explica essa opção, permitindo realizar a pesquisa totalmente offline.
+
 ---
 
 ## ⚙️ O que o código faz

--- a/css/style.css
+++ b/css/style.css
@@ -109,6 +109,12 @@ button {
   cursor: pointer;
   transition: background-color var(--transition), box-shadow 0.2s, transform 0.15s;
 }
+
+.offline-tip {
+  margin-top: 10px;
+  text-align: center;
+  color: var(--text-subtle);
+}
 button:hover,
 button:focus {
   background-color: var(--primary-dark);

--- a/index.html
+++ b/index.html
@@ -36,6 +36,8 @@
       />
       <br/>
       <button type="submit" id="connect-btn">Conectar</button>
+      <button type="button" id="skip-btn">Continuar sem conectar</button>
+      <p class="offline-tip">Caso não consiga conectar, use o botão acima para seguir direto para o questionário.</p>
     </form>
     <p id="status" role="status" aria-live="polite"></p>
   </main>

--- a/js/wifi.js
+++ b/js/wifi.js
@@ -1,5 +1,6 @@
 const wifiForm = document.getElementById("wifi-form");
 const statusDiv = document.getElementById("status");
+const skipBtn = document.getElementById("skip-btn");
 
 if (wifiForm) {
   wifiForm.addEventListener("submit", async function (e) {
@@ -28,15 +29,25 @@ if (wifiForm) {
 
       if (result.success) {
         statusDiv.innerText = "Conectado com sucesso!";
-        setTimeout(() => {
-          window.location.href = "pre.html"; //passa para próxima página
-        }, 1000);
       } else {
-        statusDiv.innerText = "Falha ao conectar.";
+        statusDiv.innerText = "Falha ao conectar. Prosseguindo sem dispositivo.";
       }
+
+      setTimeout(() => {
+        window.location.href = "pre.html"; // passa para a página de questionário
+      }, 1000);
     } catch (err) {
-      statusDiv.innerText = "Erro de conexão. Tente novamente.";
+      statusDiv.innerText = "Não foi possível conectar ao ESP32. Prosseguindo em modo de pesquisa.";
       console.error(err);
+      setTimeout(() => {
+        window.location.href = "pre.html";
+      }, 1000);
     }
+  });
+}
+
+if (skipBtn) {
+  skipBtn.addEventListener("click", () => {
+    window.location.href = "pre.html";
   });
 }


### PR DESCRIPTION
## Summary
- enable skipping Wi-Fi connection via a new "Continuar sem conectar" button
- document the skip option in README
- clarify skip instructions on the connection page

## Testing
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464c1ac1f483318b58d784836049f9