### PR TITLE
Fix offline questionnaire storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,11 @@ A página de conexão e início do Pomodoro está disponível em:
 
 👉 **https://gmraffo.github.io/webautomato/**
 
-Caso o ESP32 não esteja disponível, a tela inicial permite seguir para os questionários
-mesmo sem realizar a conexão com o dispositivo.
+Caso o ESP32 não esteja disponível, a tela inicial permite seguir para os questionários mesmo sem realizar a conexão.
+Há o botão **"Continuar sem conectar"**, que leva direto ao questionário inicial e um aviso explicando que a pesquisa pode ser feita totalmente offline.
+Se a conexão falhar, as respostas do questionário inicial são guardadas no navegador (chave `preQueue`) e enviadas automaticamente quando a rede voltar.
 
-Há também o botão **"Continuar sem conectar"**, que leva direto ao questionário inicial.
-Um aviso logo abaixo do botão explica essa opção, permitindo realizar a pesquisa totalmente offline.
-Se a conexão com a internet falhar, as respostas do questionário inicial são guardadas no navegador e enviadas automaticamente quando a rede voltar.
-
-Há também o botão **"Continuar sem conectar"**, que leva direto ao questionário inicial.
-Um aviso logo abaixo do botão explica essa opção, permitindo realizar a pesquisa totalmente offline.
-
-No questionário inicial é possível apenas enviar as respostas se preferir não iniciar o Pomodoro.
-Há dois botões: **"Enviar e iniciar Pomodoro"** ou **"Enviar sem iniciar"**, levando, respectivamente, ao cronômetro ou à página de agradecimento.
-
-Há também o botão **"Continuar sem conectar"**, que leva direto ao questionário inicial.
-Um aviso logo abaixo do botão explica essa opção, permitindo realizar a pesquisa totalmente offline.
+No questionário inicial é possível apenas enviar as respostas se preferir não iniciar o Pomodoro. Há dois botões: **"Enviar e iniciar Pomodoro"** ou **"Enviar sem iniciar"**, levando, respectivamente, ao cronômetro ou à página de agradecimento.
 
 
 ## ⚙️ O que o código faz

--- a/js/pre.js
+++ b/js/pre.js
@@ -76,44 +76,6 @@ async function enviarDados(redirecionarPara) {
   setTimeout(() => {
     window.location.href = redirecionarPara;
   }, 1200);
-
-async function enviarDados(redirecionarPara) {
-  // seleção dos botões
-  const fatigue = document.querySelector('input[name="fatigue"]:checked');
-  const motivation = document.querySelector('input[name="motivation"]:checked');
-  const productivity = document.querySelector('input[name="productivity"]:checked');
-
-  if (!fatigue || !motivation || !productivity) {
-    alert("Por favor, responda todas as perguntas antes de seguir em frente!");
-    return;
-  }
-
-  try {
-    const resposta = await fetch("https://script.google.com/macros/s/AKfycbyf4K3u5_Jg3LeEQr41e3W8JWjBo5wKKpEsjBcnmy1H6-ain0iIgIFreFg6k32JK6GZuA/exec", {
-      method: "POST",
-      body: JSON.stringify({
-        fatigue: fatigue.value,
-        motivation: motivation.value,
-        productivity: productivity.value,
-      }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    if (resposta.ok) {
-      alert("Dados enviados com sucesso! Redirecionando...");
-      setTimeout(() => {
-        window.location.href = redirecionarPara;
-      }, 1200);
-    } else {
-      alert("Erro ao enviar dados.");
-    }
-  } catch (err) {
-    alert("Erro de conexão. Tente novamente.");
-    console.error(err);
-  }
-
 }
 
 if (preForm) {


### PR DESCRIPTION
## Summary
- fix duplicated `enviarDados` function that prevented offline storage
- update README with instructions on localStorage offline queue

## Testing
- `node -c js/pre.js`

------
https://chatgpt.com/codex/tasks/task_e_684661de22e48331bb0fc7d2d4692bec